### PR TITLE
Add output.css to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.venv/
 /src/db.sqlite3
 /src/node_modules/
+/src/static/css/output.css


### PR DESCRIPTION
Ignore the output.css file in the static/css directory to prevent unnecessary clutter from generated files in version control.