### PR TITLE
Add TailwindCSS build step to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN npm i -D daisyui@latest
 # Copy project files
 COPY src .
 
+RUN npx tailwindcss -i ./static/css/input.css -o ./static/css/output.css --minify
+
 # Set environment variables
 ENV PYTHONUNBUFFERED=1
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,7 @@ services:
       - ./src/media:/code/media
     restart: unless-stopped
     command: >
-      sh -c "npx tailwindcss -i ./src/static/input.css -o ./src/static/output.css --minify &&
-             python manage.py migrate &&
+      sh -c "python manage.py migrate &&
              python manage.py collectstatic --noinput &&
              gunicorn --bind 0.0.0.0:8000 core.wsgi:application"
 


### PR DESCRIPTION
Move the TailwindCSS processing from docker-compose.yml to the Dockerfile to streamline container startup. This change helps decouple asset compilation from the application startup process, improving maintainability and deployment consistency.