### PR TITLE
Enable JIT mode in Tailwind CSS configuration.

### DIFF
--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+    mode: "jit",
     content: [
         './templates/**/*.html', // Django templates
     ],


### PR DESCRIPTION
The Just-In-Time (JIT) mode is activated in the Tailwind CSS config to improve build times and performance. This change helps in generating styles on demand, resulting in faster development experience and reduced output size.