### PR TITLE
Add volumes for Caddy data and config in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,14 @@ services:
       - ./src/caddy/Caddyfile:/etc/caddy/Caddyfile
       - ./src/staticfiles:/srv/static
       - ./src/media:/srv/media
+      - caddy_data:/data
+      - caddy_config:/config
     ports:
       - "80:80"
       - "443:443"
+      - "443:443/udp"
     restart: unless-stopped
+
+volumes:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION
Updated the `docker-compose.yml` to include volumes for `caddy_data` and `caddy_config` to persist Caddy's data and configuration. Also added support for UDP traffic on port 443. These changes improve the reliability and functionality of the Caddy service.