### PR TITLE
Set Google login to prompt account selection

### DIFF
--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -155,7 +155,6 @@ ACCOUNT_AUTHENTICATION_METHOD = "email"
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_USERNAME_REQUIRED = False
 
-
 SOCIALACCOUNT_LOGIN_ON_GET = True
 
 LOGIN_REDIRECT_URL = '/'
@@ -167,7 +166,10 @@ ACCOUNT_EMAIL_VERIFICATION = "none"
 SOCIALACCOUNT_PROVIDERS = {
     'google': {
         'SCOPE': ['profile', 'email'],
-        'AUTH_PARAMS': {'access_type': 'online'},
+        'AUTH_PARAMS': {
+            'access_type': 'online',
+            'prompt': 'select_account',
+        },
         'APP': {
             'client_id': os.getenv('OAUTH_GOOGLE_CLIENT_ID'),
             'secret': os.getenv('OAUTH_GOOGLE_CLIENT_SECRET'),


### PR DESCRIPTION
Added 'prompt: select_account' to Google OAuth AUTH_PARAMS to ensure users are explicitly prompted to select an account during login. Removed an unnecessary blank line in settings.py for code cleanliness.